### PR TITLE
Fix focus notifications timing, avatar ↔ Supabase sync and global performance score

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -57,7 +57,7 @@ const App: React.FC = () => {
   const [habits, setHabits] = useState<Habit[]>([]);
   const [goals, setGoals] = useState<Goal[]>([]);
   const [quests, setQuests] = useState<Quest[]>([]);
-  const [todayFocus, setTodayFocus] = useState<FocusSession[]>([]); // New state for live score
+  const [focusSessions, setFocusSessions] = useState<FocusSession[]>([]);
   
   const [loading, setLoading] = useState(true);
   const [syncStatus, setSyncStatus] = useState<'SYNCED' | 'SYNCING' | 'OFFLINE_PENDING'>('SYNCED');
@@ -285,14 +285,12 @@ const App: React.FC = () => {
       const { data: settingsData } = await supabase.from('user_settings').select('theme').eq('id', userId).single();
       if (settingsData && settingsData.theme) setIsDarkMode(settingsData.theme === 'dark');
 
-      const todayStr = new Date().toISOString().split('T')[0];
-
       const [tasksRes, habitsRes, goalsRes, questsRes, focusRes] = await Promise.all([
           supabase.from('tasks').select('*, subtasks(*)').eq('user_id', userId).order('created_at', { ascending: false }),
           supabase.from('habits').select('*').eq('user_id', userId).order('created_at', { ascending: true }),
           supabase.from('goals').select('*, subobjectives(*)').eq('user_id', userId),
           supabase.from('quests').select('*').eq('user_id', userId).eq('completed', false),
-          supabase.from('focus_sessions').select('*').eq('user_id', userId).gte('completed_at', todayStr) // Today only
+          supabase.from('focus_sessions').select('*').eq('user_id', userId)
       ]);
 
       if (tasksRes.data) {
@@ -312,7 +310,7 @@ const App: React.FC = () => {
           saveToCache(CACHE_KEYS.QUESTS, questsRes.data);
       }
       if (focusRes.data) {
-          setTodayFocus(focusRes.data);
+          setFocusSessions(focusRes.data);
       }
 
       const savedSession = await AsyncStorage.getItem('active_focus_session');
@@ -456,7 +454,7 @@ const App: React.FC = () => {
 
     switch (currentView) {
       case ViewState.TODAY:
-        Content = <Dashboard user={user} player={player} tasks={tasks} habits={habits} todayFocusSessions={todayFocus} toggleHabit={toggleHabit} toggleTask={toggleTask} openFocus={() => setCurrentView(ViewState.FOCUS_MODE)} openProfile={() => setProfileVisible(true)} setView={setCurrentView} syncStatus={syncStatus} openMenu={openMenuHandler} {...commonProps} />;
+        Content = <Dashboard user={user} player={player} tasks={tasks} habits={habits} goals={goals} focusSessions={focusSessions} toggleHabit={toggleHabit} toggleTask={toggleTask} openFocus={() => setCurrentView(ViewState.FOCUS_MODE)} openProfile={() => setProfileVisible(true)} setView={setCurrentView} syncStatus={syncStatus} openMenu={openMenuHandler} {...commonProps} />;
         break;
       case ViewState.PLANNING:
         Content = <Planning tasks={tasks} habits={habits} goals={goals} toggleTask={toggleTask} toggleHabit={toggleHabit} toggleGoal={()=>{}} addGoal={createGoal} deleteGoal={deleteGoal} createSubObjective={createSubObjective} toggleSubObjective={toggleSubObjective} deleteSubObjective={deleteSubObjective} userId={user.id} refreshGoals={() => fetchData(user.id)} openMenu={openMenuHandler} isDarkMode={isDarkMode} />;
@@ -489,7 +487,7 @@ const App: React.FC = () => {
         Content = <Introspection userId={user.id} openMenu={openMenuHandler} isDarkMode={isDarkMode} deleteJournalEntry={deleteJournalEntry} deleteReflection={deleteReflection} />;
         break;
       default:
-        Content = <Dashboard user={user} player={player} tasks={tasks} habits={habits} todayFocusSessions={todayFocus} toggleHabit={toggleHabit} toggleTask={toggleTask} openFocus={() => setCurrentView(ViewState.FOCUS_MODE)} openProfile={() => setProfileVisible(true)} setView={setCurrentView} syncStatus={syncStatus} openMenu={openMenuHandler} {...commonProps} />;
+        Content = <Dashboard user={user} player={player} tasks={tasks} habits={habits} goals={goals} focusSessions={focusSessions} toggleHabit={toggleHabit} toggleTask={toggleTask} openFocus={() => setCurrentView(ViewState.FOCUS_MODE)} openProfile={() => setProfileVisible(true)} setView={setCurrentView} syncStatus={syncStatus} openMenu={openMenuHandler} {...commonProps} />;
     }
 
     const bgStyle = { backgroundColor: isDarkMode ? '#000000' : '#F2F2F7' };
@@ -530,6 +528,10 @@ const App: React.FC = () => {
                             onClose={() => setProfileVisible(false)} 
                             user={user} player={player} logout={handleLogout} 
                             onThemeChange={setIsDarkMode}
+                            onPlayerUpdate={(updatedPlayer) => {
+                                setPlayer(updatedPlayer);
+                                saveToCache(CACHE_KEYS.PLAYER, updatedPlayer);
+                            }}
                         />
                         {session && (
                             <BottomNav currentView={currentView} setView={setCurrentView} isDarkMode={isDarkMode} />

--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, ScrollView, Dimensions, ActivityIndicator, Platform } from 'react-native';
-import { PlayerProfile, UserProfile, Task, Habit, ViewState, FocusSession } from '../types';
+import { PlayerProfile, UserProfile, Task, Habit, Goal, ViewState, FocusSession } from '../types';
 import { Check, Flame, Plus, Play, ChevronRight, Zap, Target, Cloud, CloudOff, RefreshCw, Menu } from 'lucide-react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
@@ -16,7 +16,8 @@ interface DashboardProps {
   player: PlayerProfile;
   tasks: Task[];
   habits: Habit[];
-  todayFocusSessions: FocusSession[]; // Nouvelle prop pour le score focus
+  goals: Goal[];
+  focusSessions: FocusSession[];
   toggleHabit: (id: string) => void;
   toggleTask: (id: string) => void;
   openFocus: () => void;
@@ -27,7 +28,7 @@ interface DashboardProps {
   openMenu: () => void;
 }
 
-const Dashboard: React.FC<DashboardProps> = ({ user, player, tasks, habits, todayFocusSessions = [], toggleHabit, toggleTask, openFocus, openProfile, setView, isDarkMode = true, syncStatus = 'SYNCED', openMenu }) => {
+const Dashboard: React.FC<DashboardProps> = ({ user, player, tasks, habits, goals, focusSessions = [], toggleHabit, toggleTask, openFocus, openProfile, setView, isDarkMode = true, syncStatus = 'SYNCED', openMenu }) => {
   const insets = useSafeAreaInsets();
   
   const colors = {
@@ -75,33 +76,33 @@ const Dashboard: React.FC<DashboardProps> = ({ user, player, tasks, habits, toda
       return aDone ? 1 : -1;
   });
 
-  // 2. Tasks
-  const activeTasks = tasks.filter(t => !t.completed).slice(0, 4); 
-  const completedTasksCount = tasks.filter(t => t.completed).length; // Idéalement filtrer par date de complétion si dispo
+  // 2. Tasks & Goals
+  const activeTasks = tasks.filter(t => !t.completed).slice(0, 4);
+  const completedTasksCount = tasks.filter(t => t.completed).length;
   const totalTasks = tasks.length;
+  const completedGoalsCount = goals.filter(g => g.completed).length;
+  const totalGoals = goals.length;
 
-  // 3. Calcul Score Cohérent
+  // 3. Calcul Score Global (cohérent et basé sur l'ensemble des données)
   const productivityScore = useMemo(() => {
-      // Score Habitudes (30%)
-      const habitsDone = todaysHabits.filter(h => h.last_completed_at && isSameDay(new Date(h.last_completed_at), today)).length;
-      const habitsTotal = todaysHabits.length;
-      const habitScore = habitsTotal > 0 ? (habitsDone / habitsTotal) * 100 : 0; // Si 0 habitudes, ne penalise pas mais ne donne pas de points
+      const habitsDoneToday = todaysHabits.filter(h => h.last_completed_at && isSameDay(new Date(h.last_completed_at), today)).length;
+      const habitsTodayRate = todaysHabits.length > 0 ? (habitsDoneToday / todaysHabits.length) * 100 : 50;
 
-      // Score Tâches (40%) - Basé sur le taux de complétion global actuel
-      const taskScore = totalTasks > 0 ? (completedTasksCount / totalTasks) * 100 : 0;
+      const averageHabitStreak = habits.length > 0
+          ? habits.reduce((acc, h) => acc + (h.streak || 0), 0) / habits.length
+          : 0;
+      const streakScore = Math.min(100, (averageHabitStreak / 30) * 100);
+      const habitScore = (habitsTodayRate * 0.6) + (streakScore * 0.4);
 
-      // Score Focus (30%) - Basé sur minutes (Objectif arbitraire 60 min)
-      const focusMinutes = todayFocusSessions.reduce((acc, session) => acc + session.duration, 0);
-      const focusScore = Math.min(100, (focusMinutes / 60) * 100);
+      const taskScore = totalTasks > 0 ? (completedTasksCount / totalTasks) * 100 : 50;
+      const goalScore = totalGoals > 0 ? (completedGoalsCount / totalGoals) * 100 : 50;
 
-      // Moyenne Pondérée
-      let score = (taskScore * 0.4) + (habitScore * 0.3) + (focusScore * 0.3);
-      
-      // Bonus si aucune habitude prévue
-      if (habitsTotal === 0) score = (taskScore * 0.5) + (focusScore * 0.5);
+      const totalFocusMinutes = focusSessions.reduce((acc, session) => acc + (session.duration || 0), 0);
+      const focusScore = Math.min(100, (totalFocusMinutes / 600) * 100); // 10h cumulées = 100
 
-      return Math.round(score) || 0;
-  }, [todaysHabits, completedTasksCount, totalTasks, todayFocusSessions]);
+      const score = (taskScore * 0.3) + (goalScore * 0.25) + (habitScore * 0.25) + (focusScore * 0.2);
+      return Math.round(score);
+  }, [todaysHabits, today, habits, totalTasks, completedTasksCount, totalGoals, completedGoalsCount, focusSessions]);
 
   // Autres stats
   const averageStreak = habits.length > 0 ? habits.reduce((acc, h) => acc + h.streak, 0) / habits.length : 0;

--- a/pages/Focus.tsx
+++ b/pages/Focus.tsx
@@ -230,19 +230,6 @@ const Focus: React.FC<FocusProps> = ({ onExit, tasks = [], isDarkMode = true, op
   };
 
   const scheduleNotifications = async (seconds: number) => {
-      const endDate = new Date(Date.now() + seconds * 1000);
-      const endHours = endDate.getHours().toString().padStart(2, '0');
-      const endMinutes = endDate.getMinutes().toString().padStart(2, '0');
-
-      await Notifications.scheduleNotificationAsync({
-          content: {
-              title: "Focus en cours 🧠",
-              body: `Session lancée. Fin prévue à ${endHours}:${endMinutes}.`,
-              sound: false,
-          },
-          trigger: null,
-      });
-
       await Notifications.scheduleNotificationAsync({
           content: {
               title: "Session Terminée ! 🎉",
@@ -251,7 +238,8 @@ const Focus: React.FC<FocusProps> = ({ onExit, tasks = [], isDarkMode = true, op
               vibrate: [0, 250, 250, 250],
           },
           trigger: {
-              seconds: seconds,
+              type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
+              seconds,
           },
       });
   };
@@ -278,6 +266,7 @@ const Focus: React.FC<FocusProps> = ({ onExit, tasks = [], isDarkMode = true, op
           startTime: now
       };
       await AsyncStorage.setItem('active_focus_session', JSON.stringify(sessionData));
+      await cancelNotifications();
       await scheduleNotifications(d * 60);
 
       setDurationMinutes(d);
@@ -299,6 +288,7 @@ const Focus: React.FC<FocusProps> = ({ onExit, tasks = [], isDarkMode = true, op
       setIsActive(false);
       setEndTimeTimestamp(null);
       await AsyncStorage.removeItem('active_focus_session');
+      await cancelNotifications();
       playSuccess();
 
       const { data: { user } } = await supabase.auth.getUser();

--- a/pages/Profile.tsx
+++ b/pages/Profile.tsx
@@ -15,6 +15,7 @@ interface ProfileProps {
   visible: boolean;
   onClose: () => void;
   onThemeChange?: (isDark: boolean) => void;
+  onPlayerUpdate?: (player: PlayerProfile) => void;
 }
 
 const DEFAULT_AI_PERMISSIONS: AiPermissions = {
@@ -91,7 +92,7 @@ const AVATAR_HELMETS: AvatarHelmet[] = ['standard', 'visor', 'crown', 'halo'];
 const AVATAR_ARMORS: AvatarArmor[] = ['standard', 'heavy', 'stealth', 'energy'];
 const AVATAR_COLORS: AvatarColor[] = ['#C4B5FD', '#34D399', '#F472B6', '#60A5FA', '#FACC15', '#F87171', '#A78BFA'];
 
-const Profile: React.FC<ProfileProps> = ({ user, player, logout, visible, onClose, onThemeChange }) => {
+const Profile: React.FC<ProfileProps> = ({ user, player, logout, visible, onClose, onThemeChange, onPlayerUpdate }) => {
   const insets = useSafeAreaInsets();
   const [loading, setLoading] = useState(false);
   const [activeTab, setActiveTab] = useState<'PROFILE' | 'SETTINGS' | 'STATS'>('PROFILE');
@@ -156,6 +157,18 @@ const Profile: React.FC<ProfileProps> = ({ user, player, logout, visible, onClos
       }
   }, [visible]);
 
+
+  useEffect(() => {
+      if (visible) {
+          setAvatarConfig(player.avatar_customization || {
+              class: 'cyber_knight',
+              helmet: 'standard',
+              armor: 'standard',
+              color: '#C4B5FD'
+          });
+      }
+  }, [player.avatar_customization, visible]);
+
   const fetchSettings = async () => {
       setLoading(true);
       const { data } = await supabase.from('user_settings').select('*').eq('id', user.id).single();
@@ -187,13 +200,17 @@ const Profile: React.FC<ProfileProps> = ({ user, player, logout, visible, onClos
 
   const saveAvatar = async () => {
       setLoading(true);
-      const { error } = await supabase.from('player_profiles').update({
-          avatar_customization: avatarConfig
-      }).eq('user_id', user.id);
+      const { data, error } = await supabase
+          .from('player_profiles')
+          .update({ avatar_customization: avatarConfig })
+          .eq('user_id', user.id)
+          .select('*')
+          .single();
 
-      if (error) Alert.alert("Erreur", "Impossible de sauvegarder l'avatar.");
-      else {
-          player.avatar_customization = avatarConfig;
+      if (error) {
+          Alert.alert("Erreur", "Impossible de sauvegarder l'avatar.");
+      } else if (data) {
+          onPlayerUpdate?.(data as PlayerProfile);
           setIsEditingAvatar(false);
       }
       setLoading(false);


### PR DESCRIPTION
### Motivation
- Éviter des notifications de « félicitations » envoyées au démarrage d'une session Focus et garantir que les notifications planifiées sont correctement réinitialisées. 
- Rendre l'édition/sauvegarde de l'avatar parfaitement cohérente avec Supabase et propager le joueur mis à jour dans l'état global de l'app. 
- Produire un score de performance globale cohérent qui prend en compte l’ensemble des données (tâches, objectifs, habitudes, focus). 

### Description
- Focus: supprime la notification immédiate au démarrage et ne planifie que la notification de fin de session via un déclencheur temporel; annule les notifications existantes au démarrage/arrêt/complétion pour éviter les doublons (`pages/Focus.tsx`).
- Profil / Avatar: `saveAvatar` utilise maintenant `update(...).select().single()` pour récupérer la ligne mise à jour depuis Supabase et appelle un callback `onPlayerUpdate` pour mettre à jour l'état `player` de l'application; l'éditeur d'avatar synchronise son état avec `player.avatar_customization` quand le profil s'ouvre (`pages/Profile.tsx`, `App.tsx`).
- Dashboard / Score: remonte désormais toutes les sessions Focus et les goals depuis `App` et passe `goals` + `focusSessions` au `Dashboard`; le calcul `productivityScore` a été rendu plus complet et pondéré (tâches, objectifs, habitudes, focus cumulé) pour refléter l'état global (`pages/Dashboard.tsx`, `App.tsx`).
- UI Tâches: le comportement demandé du bouton `+` en haut à droite ouvrant un modal avec titre/priorité/description/date est déjà présent et conservé (`pages/Tasks.tsx`).

### Testing
- Lint/typecheck: exécuté `npm run typecheck` (runs `tsc --noEmit`) et a échoué avec erreurs TypeScript existantes non liées aux changements (problèmes de typings `vite` et un avertissement d'énumération dans `App.tsx`), test échoué.
- Tentative de build/run: `npm run build` absent (échec), et tentative `npm run web -- --port 4173` (Expo) a démarré mais a échoué en runtime dans cet environnement avec `TypeError: fetch failed`, lancement non abouti.
- Modifications fonctionnelles locales: changements manuels appliqués et vérifiés par inspection du code pour garantir que la planification/annulation des notifications et la remontée des données avatar/focus sont en place; aucun test automatisé complet réussi dans cet environnement CI local.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af9383ec08333aeb0a380c72e508d)