### PR TITLE
Improve Google Calendar OAuth reliability, startup session handling, and Gemini key detection

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -48,7 +48,8 @@ const App: React.FC = () => {
   const [levelUpVisible, setLevelUpVisible] = useState(false);
   const previousLevelRef = useRef<number>(1);
   
-  const [session, setSession] = useState<any>(null);
+  // undefined = session en cours de chargement, null = non connecté.
+  const [session, setSession] = useState<any | null | undefined>(undefined);
   const [user, setUser] = useState<UserProfile | null>(null);
   const [player, setPlayer] = useState<PlayerProfile | null>(null);
   
@@ -445,6 +446,12 @@ const App: React.FC = () => {
     );
 
     if (currentView === ViewState.ONBOARDING) return <Onboarding onFinish={finishOnboarding} />;
+    if (session === undefined) return (
+        <View style={{ flex: 1, backgroundColor: isDarkMode ? '#000' : '#F2F2F7' }}>
+            <SkeletonDashboard />
+        </View>
+    );
+
     if (!session || !user || !player) return <Auth onLogin={() => fetchData(session?.user?.id)} />;
 
     const commonProps = { isDarkMode };
@@ -513,7 +520,7 @@ const App: React.FC = () => {
                     <LevelUpModal visible={levelUpVisible} newLevel={player.level} onClose={() => setLevelUpVisible(false)} />
                 )}
 
-                {currentView !== ViewState.ONBOARDING && user && player && (
+                {user && player && (
                     <>
                         <Sidebar 
                             visible={isSidebarVisible} 

--- a/README.md
+++ b/README.md
@@ -18,3 +18,45 @@ View your app in AI Studio: https://ai.studio/apps/drive/15J7Dmeu0d3Sr10BscYOB5e
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+
+## Configuration Expo (.env) recommandée
+
+Crée un fichier `.env` à la racine avec :
+
+```env
+# Supabase
+EXPO_PUBLIC_SUPABASE_URL=...
+EXPO_PUBLIC_SUPABASE_ANON_KEY=...
+
+# IA Gemini (Expo client)
+EXPO_PUBLIC_GEMINI_API_KEY=...
+
+# Google OAuth
+EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=...
+EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=...
+EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=...
+# Obligatoire si vous testez dans Expo Go
+EXPO_PUBLIC_GOOGLE_EXPO_CLIENT_ID=...
+```
+
+Puis redémarre Expo en vidant le cache :
+
+```bash
+npx expo start -c
+```
+
+## Google Calendar : checklist pour une connexion fiable
+
+1. Dans Google Cloud Console, active **Google Calendar API**.
+2. Configure l'écran de consentement OAuth (en mode *Testing* ou *Production*).
+3. Crée les OAuth Client IDs correspondants :
+   - **Web client** (pour web),
+   - **iOS client** (bundle id `com.deepflow.app`),
+   - **Android client** (package `com.deepflow.app` + SHA-1/SHA-256),
+   - **Expo client** si test dans Expo Go.
+4. Mets chaque client ID dans la variable `.env` correspondante.
+5. Ajoute votre compte Google dans les testeurs OAuth si l'app est en mode *Testing*.
+6. Relance l'app puis ouvre l'écran **Calendrier** et appuie sur l'icône Google.
+
+> Note : sur Android/iOS, un client ID invalide (ou mauvais package/bundle/SHA) provoque une connexion refusée même si la clé est présente dans `.env`.

--- a/pages/CalendarPage.tsx
+++ b/pages/CalendarPage.tsx
@@ -1,27 +1,36 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Alert, ActivityIndicator, Platform, Dimensions } from 'react-native';
 import { Plus, ChevronLeft, ChevronRight, CheckCircle2, Circle, Calendar as CalendarIcon, MapPin, Clock, AlignLeft, LogIn, Menu } from 'lucide-react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Task, Habit, CalendarEvent } from '../types';
 import * as Google from 'expo-auth-session/providers/google';
 import * as WebBrowser from 'expo-web-browser';
+import Constants from 'expo-constants';
 import { playMenuClick } from '../services/sound';
 import Animated, { FadeIn, LayoutAnimationConfig } from 'react-native-reanimated';
 import { supabase } from '../services/supabase';
 
 WebBrowser.maybeCompleteAuthSession();
 
-// --- CONFIGURATION GOOGLE - Secured via Environment Variables ---
-// Fallback to 'dummy' IDs to prevent app crash if keys are missing in .env
+// --- CONFIGURATION GOOGLE ---
+// Expo n'expose côté client que les variables EXPO_PUBLIC_*
 const GOOGLE_CONFIG = {
-    webClientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID || 'dummy_web_client_id',
-    androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID || 'dummy_android_client_id',
-    iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID || 'dummy_ios_client_id',
+    expoClientId: process.env.EXPO_PUBLIC_GOOGLE_EXPO_CLIENT_ID || '',
+    webClientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID || '',
+    androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID || '',
+    iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID || '',
 };
 
-const hasValidGoogleConfig = 
-    GOOGLE_CONFIG.androidClientId !== 'dummy_android_client_id' && 
-    GOOGLE_CONFIG.iosClientId !== 'dummy_ios_client_id';
+const appOwnership = Constants.appOwnership;
+const isExpoGo = appOwnership === 'expo';
+
+const hasGoogleClientIdForCurrentPlatform = () => {
+    if (isExpoGo) return !!GOOGLE_CONFIG.expoClientId;
+    if (Platform.OS === 'ios') return !!GOOGLE_CONFIG.iosClientId;
+    if (Platform.OS === 'android') return !!GOOGLE_CONFIG.androidClientId;
+    if (Platform.OS === 'web') return !!GOOGLE_CONFIG.webClientId;
+    return false;
+};
 
 interface CalendarPageProps {
     tasks: Task[];
@@ -69,9 +78,10 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ tasks, habits, toggleTask, 
 
     // Google Auth Request - Safely initialized with dummy IDs if real ones missing
     const [request, response, promptAsync] = Google.useAuthRequest({
-        iosClientId: GOOGLE_CONFIG.iosClientId,
-        androidClientId: GOOGLE_CONFIG.androidClientId,
-        webClientId: GOOGLE_CONFIG.webClientId,
+        clientId: GOOGLE_CONFIG.expoClientId || GOOGLE_CONFIG.webClientId || undefined,
+        iosClientId: GOOGLE_CONFIG.iosClientId || undefined,
+        androidClientId: GOOGLE_CONFIG.androidClientId || undefined,
+        webClientId: GOOGLE_CONFIG.webClientId || undefined,
         scopes: ['https://www.googleapis.com/auth/calendar.readonly', 'https://www.googleapis.com/auth/calendar.events'],
     });
 
@@ -129,7 +139,10 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ tasks, habits, toggleTask, 
                 headers: { Authorization: `Bearer ${token}` }
             });
             
-            if (!res.ok) throw new Error("Google API Error");
+            if (!res.ok) {
+                const errText = await res.text();
+                throw new Error(`Google API Error ${res.status}: ${errText}`);
+            }
 
             const data = await res.json();
             
@@ -156,15 +169,31 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ tasks, habits, toggleTask, 
         }
     };
 
-    const handleGoogleConnect = () => {
-        if (!hasValidGoogleConfig) {
-            Alert.alert("Configuration Manquante", "Les clés API Google (Client IDs) ne sont pas configurées dans le fichier .env.");
+    const handleGoogleConnect = async () => {
+        if (!hasGoogleClientIdForCurrentPlatform()) {
+            const expected = isExpoGo
+                ? 'EXPO_PUBLIC_GOOGLE_EXPO_CLIENT_ID'
+                : Platform.OS === 'ios'
+                    ? 'EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID'
+                    : Platform.OS === 'android'
+                        ? 'EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID'
+                        : 'EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID';
+
+            Alert.alert(
+                'Configuration Manquante',
+                `Client ID Google manquant pour cette plateforme. Ajoute ${expected} dans le .env puis redémarre Expo avec le cache vidé.`
+            );
             return;
         }
+
         if (googleToken) {
             fetchGoogleCalendarEvents(googleToken);
-        } else {
-            promptAsync();
+            return;
+        }
+
+        const result = await promptAsync();
+        if (result?.type !== 'success' && result?.type !== 'dismiss') {
+            Alert.alert('Connexion Google', 'Connexion annulée ou refusée.');
         }
     };
 
@@ -375,8 +404,8 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ tasks, habits, toggleTask, 
                 
                 <View style={styles.headerControls}>
                     {!googleToken && (
-                        <TouchableOpacity onPress={handleGoogleConnect} style={[styles.googleBtn, { backgroundColor: hasValidGoogleConfig ? 'rgba(234, 67, 53, 0.1)' : '#333' }]} disabled={isLoadingGoogle}>
-                            {isLoadingGoogle ? <ActivityIndicator size="small" color={colors.googleRed} /> : <CalendarIcon size={20} color={hasValidGoogleConfig ? colors.googleRed : '#555'} />}
+                        <TouchableOpacity onPress={handleGoogleConnect} style={[styles.googleBtn, { backgroundColor: hasGoogleClientIdForCurrentPlatform() ? 'rgba(234, 67, 53, 0.1)' : '#333' }]} disabled={isLoadingGoogle || !request}>
+                            {isLoadingGoogle ? <ActivityIndicator size="small" color={colors.googleRed} /> : <CalendarIcon size={20} color={hasGoogleClientIdForCurrentPlatform() ? colors.googleRed : '#555'} />}
                         </TouchableOpacity>
                     )}
                     <View style={[styles.viewToggle, { backgroundColor: colors.toggleBg }]}>

--- a/services/ai.ts
+++ b/services/ai.ts
@@ -1,8 +1,13 @@
 import { GoogleGenAI } from "@google/genai";
 import { supabase } from './supabase';
 
-// Logique pour s'assurer que la clé est bien chargée
-const getApiKey = () => process.env.API_KEY;
+// Expo n'expose côté client que les variables préfixées par EXPO_PUBLIC_.
+// On garde des fallbacks pour compatibilité (web / anciennes configs).
+const getApiKey = () => (
+    process.env.EXPO_PUBLIC_GEMINI_API_KEY ||
+    process.env.GEMINI_API_KEY ||
+    process.env.API_KEY
+);
 
 async function logAiUsage(type: 'chat' | 'analysis') {
     try {
@@ -42,7 +47,7 @@ export const generateActionableCoaching = async (
 ): Promise<{ text: string, action?: any }> => {
   const apiKey = getApiKey();
   if (!apiKey) {
-      console.warn("API Key manquante dans process.env.API_KEY");
+      console.warn("API Key manquante. Utilisez EXPO_PUBLIC_GEMINI_API_KEY dans votre .env.");
       return { text: "⚠️ IA non configurée (Clé manquante dans le fichier .env)." };
   }
 


### PR DESCRIPTION
### Motivation
- Ensure Google Calendar OAuth works reliably across Expo runtimes (Expo Go / Android / iOS / Web) because previous checks were too brittle and caused silent failures.  
- Prevent a startup UI flicker to `Auth` while session restoration is in progress.  
- Make Gemini/AI key detection work in Expo builds where only `EXPO_PUBLIC_*` env vars are exposed and improve diagnostics when the key is missing.

### Description
- Pages: `pages/CalendarPage.tsx` now reads per-platform client IDs (`EXPO_PUBLIC_GOOGLE_EXPO_CLIENT_ID`, `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID`, `EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID`, `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID`) and validates the expected client ID for the current runtime before launching OAuth.  
- `useAuthRequest` is wired with a safer `clientId` fallback for Expo Go/web while still supplying `iosClientId`/`androidClientId` for native builds, and the Google connect button is disabled until the request is ready.  
- Google API error handling improved to log HTTP status + response body for easier diagnosis of scope/consent/test-user issues.  
- App startup: `App.tsx` initializes `session` as `undefined` to represent the loading state and renders `SkeletonDashboard` while session restoration completes, preventing the brief auth->home flicker; sidebar/footer gating was relaxed to show UI only when `user` and `player` exist.  
- AI service: `services/ai.ts` `getApiKey()` now prefers `EXPO_PUBLIC_GEMINI_API_KEY` with fallbacks to `GEMINI_API_KEY` and `API_KEY`, and the missing-key warning now references the Expo public env var.  
- Docs: `README.md` updated with an Expo `.env` example (including `EXPO_PUBLIC_GOOGLE_EXPO_CLIENT_ID`) and a Google Cloud checklist (enable Calendar API, configure OAuth consent, create per-platform client IDs, add test users, restart Expo with `npx expo start -c`).

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`); TypeScript still fails due to pre-existing `vite` typing issues in `vite.config.ts` (missing `vite` / `@vitejs/plugin-react` types), and there are no new TS errors introduced by the Calendar/App/AI changes.  
- Attempted to run the app web with `npm run web -- --port 19007`; Expo CLI failed in this environment with `TypeError: fetch failed` while checking native module versions, which is an environment/CLI networking issue rather than a code regression.  
- Performed local code edits and committed changes (`Improve Google Calendar OAuth reliability and onboarding docs`), and added README onboarding steps to manually validate Google Calendar integration: add per-platform client IDs to `.env`, enable Calendar API, configure consent screen and OAuth test users, then restart Expo with `npx expo start -c` and open the Calendar page to authenticate.  
- No automated runtime tests were added; manual validation steps are documented in `README.md` to reproduce and verify a successful Google Calendar connection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b1556e0d08333ad0a5b2b54e1847f)