### PR TITLE
Limit Metro workers to prevent bundling crashes

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -2,4 +2,8 @@ const { getDefaultConfig } = require('expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
 
+// Limit the number of workers to reduce memory pressure during bundling.
+// This helps prevent SIGTERM crashes in resource-constrained environments.
+config.maxWorkers = 2;
+
 module.exports = config;


### PR DESCRIPTION
This change addresses a critical bundling failure during Android builds where worker processes were terminated with a `SIGTERM` signal. The issue was identified as a memory exhaustion problem during module transformation (specifically affecting `react-native-gesture-handler`). By limiting Metro's concurrency to 2 workers, we ensure the total memory footprint remains within safe limits for the build environment without significantly impacting build performance. Verified by successfully exporting the Android bundle.

---
*PR created automatically by Jules for task [12807325815228307792](https://jules.google.com/task/12807325815228307792) started by @lsapk*