### PR TITLE
Fix Android bundling failure and TypeScript errors

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -4,6 +4,6 @@ const config = getDefaultConfig(__dirname);
 
 // Limit the number of workers to reduce memory pressure during bundling.
 // This helps prevent SIGTERM crashes in resource-constrained environments.
-config.maxWorkers = 2;
+config.maxWorkers = 1;
 
 module.exports = config;

--- a/pages/Habits.tsx
+++ b/pages/Habits.tsx
@@ -17,6 +17,7 @@ interface HabitsProps {
   refreshHabits: () => void;
   openMenu: () => void;
   isDarkMode?: boolean;
+  noPadding?: boolean;
 }
 
 const DAYS = ['D', 'L', 'M', 'M', 'J', 'V', 'S'];

--- a/pages/Tasks.tsx
+++ b/pages/Tasks.tsx
@@ -22,6 +22,7 @@ interface TasksProps {
   refreshTasks: () => void;
   openMenu: () => void; 
   isDarkMode?: boolean;
+  noPadding?: boolean;
 }
 
 const Tasks: React.FC<TasksProps> = ({ tasks, goals, toggleTask, addTask, deleteTask, createSubtask, toggleSubtask, deleteSubtask, userId, refreshTasks, openMenu, isDarkMode = true }) => {

--- a/types.ts
+++ b/types.ts
@@ -42,6 +42,14 @@ export interface UserRole {
   updated_at?: string;
 }
 
+export interface AvatarConfig {
+  class?: string;
+  helmet?: string;
+  armor?: string;
+  color?: string;
+  glow_color?: string;
+}
+
 export interface Announcement {
   id: string;
   title: string;


### PR DESCRIPTION
This change resolves the Android bundling failure where a jest worker process was terminated by a SIGTERM signal. The fix involves reducing the number of Metro workers to 1 in `metro.config.js`, which lowers memory consumption during the bundling process. Additionally, several pre-existing TypeScript errors were fixed to ensure the codebase remains stable and passes type checking.

---
*PR created automatically by Jules for task [15191376762752537493](https://jules.google.com/task/15191376762752537493) started by @lsapk*