### PR TITLE
Fix Android bundling SIGTERM and TypeScript errors

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -4,6 +4,6 @@ const config = getDefaultConfig(__dirname);
 
 // Limit the number of workers to reduce memory pressure during bundling.
 // This helps prevent SIGTERM crashes in resource-constrained environments.
-config.maxWorkers = 2;
+config.maxWorkers = 1;
 
 module.exports = config;

--- a/pages/Habits.tsx
+++ b/pages/Habits.tsx
@@ -17,12 +17,13 @@ interface HabitsProps {
   refreshHabits: () => void;
   openMenu: () => void;
   isDarkMode?: boolean;
+  noPadding?: boolean;
 }
 
 const DAYS = ['D', 'L', 'M', 'M', 'J', 'V', 'S'];
 const { width } = Dimensions.get('window');
 
-const Habits: React.FC<HabitsProps> = ({ habits, goals, incrementHabit, userId, createHabit, archiveHabit, deleteHabit, refreshHabits, openMenu, isDarkMode = true }) => {
+const Habits: React.FC<HabitsProps> = ({ habits, goals, incrementHabit, userId, createHabit, archiveHabit, deleteHabit, refreshHabits, openMenu, isDarkMode = true, noPadding = false }) => {
   const [showArchived, setShowArchived] = useState(false);
   const [viewMode, setViewMode] = useState<'LIST' | 'GRID'>('LIST');
   const [filterMode, setFilterMode] = useState<'TODAY' | 'ALL'>('TODAY');
@@ -267,7 +268,7 @@ const Habits: React.FC<HabitsProps> = ({ habits, goals, incrementHabit, userId, 
   );
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+    <View style={[styles.container, { backgroundColor: colors.bg, paddingTop: noPadding ? 0 : 20 }]}>
       {/* HEADER iOS Style */}
       <View style={styles.header}>
          <View style={{flexDirection: 'row', alignItems: 'center'}}>

--- a/pages/Tasks.tsx
+++ b/pages/Tasks.tsx
@@ -22,9 +22,10 @@ interface TasksProps {
   refreshTasks: () => void;
   openMenu: () => void; 
   isDarkMode?: boolean;
+  noPadding?: boolean;
 }
 
-const Tasks: React.FC<TasksProps> = ({ tasks, goals, toggleTask, addTask, deleteTask, createSubtask, toggleSubtask, deleteSubtask, userId, refreshTasks, openMenu, isDarkMode = true }) => {
+const Tasks: React.FC<TasksProps> = ({ tasks, goals, toggleTask, addTask, deleteTask, createSubtask, toggleSubtask, deleteSubtask, userId, refreshTasks, openMenu, isDarkMode = true, noPadding = false }) => {
   const insets = useSafeAreaInsets(); // Hook pour gérer les marges de sécurité (encoche, barre home)
   
   const [isReady, setIsReady] = useState(false);
@@ -202,7 +203,7 @@ const Tasks: React.FC<TasksProps> = ({ tasks, goals, toggleTask, addTask, delete
   );
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+    <View style={[styles.container, { backgroundColor: colors.bg, paddingTop: noPadding ? 0 : 20 }]}>
       <View style={styles.header}>
           <View style={{flex: 1}}>
             <Text style={[styles.largeTitle, {color: colors.text}]}>Tâches</Text>

--- a/types.ts
+++ b/types.ts
@@ -42,6 +42,14 @@ export interface UserRole {
   updated_at?: string;
 }
 
+export interface AvatarConfig {
+  class: string;
+  helmet: string;
+  armor: string;
+  color: string;
+  glow_color: string;
+}
+
 export interface Announcement {
   id: string;
   title: string;


### PR DESCRIPTION
This PR addresses the Android bundling failure caused by a `SIGTERM` signal, typically due to memory exhaustion in the Metro bundler. By limiting the number of worker processes to 1, we reduce the memory footprint during the bundling process.

Additionally, this PR fixes several TypeScript compilation errors that were blocking the build:
- Exported the `AvatarConfig` interface in `types.ts`.
- Added the `noPadding` optional prop to `TasksProps` and `HabitsProps` and implemented the corresponding UI logic to handle conditional top padding.

Verified the fix by running `npm run lint`, `npm run typecheck`, and successfully exporting the Android bundle using `npx expo export --platform android`.

---
*PR created automatically by Jules for task [17278334305536856817](https://jules.google.com/task/17278334305536856817) started by @lsapk*