### PR TITLE
Fix Android bundling SIGTERM error by reducing Metro workers

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -4,6 +4,6 @@ const config = getDefaultConfig(__dirname);
 
 // Limit the number of workers to reduce memory pressure during bundling.
 // This helps prevent SIGTERM crashes in resource-constrained environments.
-config.maxWorkers = 2;
+config.maxWorkers = 1;
 
 module.exports = config;


### PR DESCRIPTION
The Android bundling process was failing with a `SIGTERM` error due to memory exhaustion in worker processes. This change reduces `config.maxWorkers` to 1 in `metro.config.js` to minimize memory usage during bundling, ensuring stability in resource-constrained environments. Verification was performed by successfully running `npx expo export --platform android`.

---
*PR created automatically by Jules for task [200139962358443055](https://jules.google.com/task/200139962358443055) started by @lsapk*