### PR TITLE
Fix Android Bundling Failure and Type Errors

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -4,6 +4,6 @@ const config = getDefaultConfig(__dirname);
 
 // Limit the number of workers to reduce memory pressure during bundling.
 // This helps prevent SIGTERM crashes in resource-constrained environments.
-config.maxWorkers = 2;
+config.maxWorkers = 1;
 
 module.exports = config;

--- a/pages/Habits.tsx
+++ b/pages/Habits.tsx
@@ -17,12 +17,13 @@ interface HabitsProps {
   refreshHabits: () => void;
   openMenu: () => void;
   isDarkMode?: boolean;
+  noPadding?: boolean;
 }
 
 const DAYS = ['D', 'L', 'M', 'M', 'J', 'V', 'S'];
 const { width } = Dimensions.get('window');
 
-const Habits: React.FC<HabitsProps> = ({ habits, goals, incrementHabit, userId, createHabit, archiveHabit, deleteHabit, refreshHabits, openMenu, isDarkMode = true }) => {
+const Habits: React.FC<HabitsProps> = ({ habits, goals, incrementHabit, userId, createHabit, archiveHabit, deleteHabit, refreshHabits, openMenu, isDarkMode = true, noPadding = false }) => {
   const [showArchived, setShowArchived] = useState(false);
   const [viewMode, setViewMode] = useState<'LIST' | 'GRID'>('LIST');
   const [filterMode, setFilterMode] = useState<'TODAY' | 'ALL'>('TODAY');
@@ -267,7 +268,7 @@ const Habits: React.FC<HabitsProps> = ({ habits, goals, incrementHabit, userId, 
   );
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+    <View style={[styles.container, { backgroundColor: colors.bg, paddingTop: noPadding ? 0 : 20 }]}>
       {/* HEADER iOS Style */}
       <View style={styles.header}>
          <View style={{flexDirection: 'row', alignItems: 'center'}}>
@@ -392,7 +393,6 @@ const Habits: React.FC<HabitsProps> = ({ habits, goals, incrementHabit, userId, 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: 20,
   },
   header: {
     flexDirection: 'row',

--- a/pages/Tasks.tsx
+++ b/pages/Tasks.tsx
@@ -22,9 +22,10 @@ interface TasksProps {
   refreshTasks: () => void;
   openMenu: () => void; 
   isDarkMode?: boolean;
+  noPadding?: boolean;
 }
 
-const Tasks: React.FC<TasksProps> = ({ tasks, goals, toggleTask, addTask, deleteTask, createSubtask, toggleSubtask, deleteSubtask, userId, refreshTasks, openMenu, isDarkMode = true }) => {
+const Tasks: React.FC<TasksProps> = ({ tasks, goals, toggleTask, addTask, deleteTask, createSubtask, toggleSubtask, deleteSubtask, userId, refreshTasks, openMenu, isDarkMode = true, noPadding = false }) => {
   const insets = useSafeAreaInsets(); // Hook pour gérer les marges de sécurité (encoche, barre home)
   
   const [isReady, setIsReady] = useState(false);
@@ -202,7 +203,7 @@ const Tasks: React.FC<TasksProps> = ({ tasks, goals, toggleTask, addTask, delete
   );
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+    <View style={[styles.container, { backgroundColor: colors.bg, paddingTop: noPadding ? 0 : 20 }]}>
       <View style={styles.header}>
           <View style={{flex: 1}}>
             <Text style={[styles.largeTitle, {color: colors.text}]}>Tâches</Text>
@@ -378,7 +379,7 @@ const TaskItem = React.memo(({ task, onToggle, onLongPress, colors, priorityColo
 });
 
 const styles = StyleSheet.create({
-  container: { flex: 1, paddingTop: 20 },
+  container: { flex: 1 },
   header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 20, marginBottom: 16, marginTop: 20 },
   largeTitle: { fontSize: 34, fontWeight: '800', letterSpacing: 0.37 },
   subtitle: { fontSize: 15, fontWeight: '500', marginTop: 4 },

--- a/types.ts
+++ b/types.ts
@@ -63,6 +63,14 @@ export interface PlatformStats {
   totalFocusHours: number;
 }
 
+export interface AvatarConfig {
+  class?: string;
+  helmet?: string;
+  armor?: string;
+  color?: string;
+  glow_color?: string;
+}
+
 export interface AiPermissions {
     tasks: boolean;
     habits: boolean;


### PR DESCRIPTION
This PR resolves the Android bundling failure (SIGTERM) by limiting the number of Metro bundler workers to 1, which reduces memory consumption during the build process. Additionally, it fixes several TypeScript errors related to missing type exports and props that were causing `npm run typecheck` to fail, ensuring a stable and buildable codebase.

---
*PR created automatically by Jules for task [1336990551148413179](https://jules.google.com/task/1336990551148413179) started by @lsapk*